### PR TITLE
资源重复释放

### DIFF
--- a/KSFramework/Assets/KSFramework/KEngine/KEngine/CoreModules/ResourceModule/KAbstractResourceLoader.cs
+++ b/KSFramework/Assets/KSFramework/KEngine/KEngine/CoreModules/ResourceModule/KAbstractResourceLoader.cs
@@ -396,6 +396,7 @@ namespace KEngine
                 Log.Warning("[ForceDisose]Use force dispose to dispose loader, recommend this loader RefCount == 1");
             }
             Dispose();
+            IsReadyDisposed = true;
         }
 
         /// <summary>

--- a/KSFramework/Assets/KSFramework/KEngine/KEngine/CoreModules/ResourceModule/SceneLoader.cs
+++ b/KSFramework/Assets/KSFramework/KEngine/KEngine/CoreModules/ResourceModule/SceneLoader.cs
@@ -164,7 +164,6 @@ namespace KEngine
         protected override void DoDispose()
         {
             base.DoDispose();
-            _assetFileBridge.Release();
             if (_loadedSceneName == _sceneName)
             {
                 SceneManager.UnloadSceneAsync(_sceneName);


### PR DESCRIPTION
1.  SceneLoader.OnReadyDisposed已经执行_assetFileBridge.ForceDispose()释放了资源，SceneLoader.DoDispose不用再执行一次
2. ForceDispose设置IsReadyDisposed状态，不然，Release检测不到重复释放